### PR TITLE
Update sawtooth-default.yaml

### DIFF
--- a/LFS171x/sawtooth-material/sawtooth-default.yaml
+++ b/LFS171x/sawtooth-material/sawtooth-default.yaml
@@ -13,12 +13,12 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-version: "2.1"
+version: "2"
 
 services:
 
   settings-tp:
-    image: hyperledger/sawtooth-tp_settings:latest
+    image: hyperledger/sawtooth-settings-tp:0.8
     container_name: sawtooth-settings-tp-default
     expose:
       - 4004
@@ -27,7 +27,7 @@ services:
     entrypoint: settings-tp -vv tcp://validator:4004
 
   intkey-tp-python:
-    image: hyperledger/sawtooth-tp_intkey_python:latest
+    image: hyperledger/sawtooth-intkey-tp-python:0.8
     container_name: sawtooth-intkey-tp-python-default
     expose:
       - 4004
@@ -36,7 +36,7 @@ services:
     entrypoint: intkey-tp-python -vv tcp://validator:4004
 
   xo-tp-python:
-    image: hyperledger/sawtooth-tp_xo_python:latest
+    image: hyperledger/sawtooth-xo-tp-python:0.8
     container_name: sawtooth-xo-tp-python-default
     expose:
       - 4004
@@ -45,7 +45,7 @@ services:
     entrypoint: xo-tp-python -vv tcp://validator:4004
 
   validator:
-    image: hyperledger/sawtooth-validator:latest
+    image: hyperledger/sawtooth-validator:0.8
     container_name: sawtooth-validator-default
     expose:
       - 4004
@@ -64,7 +64,7 @@ services:
         \""
 
   rest-api:
-    image: hyperledger/sawtooth-rest_api:latest
+    image: hyperledger/sawtooth-rest-api:0.8
     container_name: sawtooth-rest-api-default
     expose:
       - 4004
@@ -76,7 +76,7 @@ services:
     entrypoint: sawtooth-rest-api --connect tcp://validator:4004 --bind rest-api:8080
 
   client:
-    image: hyperledger/sawtooth-all:latest
+    image: hyperledger/sawtooth-all:0.8
     container_name: sawtooth-client-default
     expose:
       - 8080


### PR DESCRIPTION
docker compose was not working with version: "2.1" => switched to "2"
Docker images were not up-to-date and Validator was giving error
---------------------
#17	---  Validator Timed Out	--- The request timed out while waiting for a response from the validator. It may not be running, or have encountered an internal error. The request may or may not have been processed.
---------------------
So, docker images name changed to latest and 0.8 is latest stable version. Once 1.0 is stable and release, we can switch back to "latest"