### PR TITLE
Removing double instatiation of app

### DIFF
--- a/LFS171x/fabric-material/tuna-app/server.js
+++ b/LFS171x/fabric-material/tuna-app/server.js
@@ -20,8 +20,6 @@ var os            = require('os');
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
-// instantiate the app
-var app = express();
 
 // this line requires and runs the code from our routes.js file and passes it app
 require('./routes.js')(app);


### PR DESCRIPTION
I think the reason why all the requests use get instead of post is that for req.body didn't work, it was because app was instantiated twice thus overwriting the encoders