### PR TITLE
Update the sawtooth-default.yaml

### DIFF
--- a/LFS171x/sawtooth-material/sawtooth-default.yaml
+++ b/LFS171x/sawtooth-material/sawtooth-default.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-version: "2.1"
+version: "2.0"
 
 services:
 


### PR DESCRIPTION
Update the sawtooth default docker-compose
version to 2.0 since it does fails with 2.1

Fixes: #22
Signed-off-by: Swapnil Kulkarni <me@coolsvap.net>