### PR TITLE
Wait until batch is committed before refresh

### DIFF
--- a/LFS171x/sawtooth-material/sawtooth-tuna/client/src/state.js
+++ b/LFS171x/sawtooth-material/sawtooth-tuna/client/src/state.js
@@ -119,12 +119,14 @@ const submitUpdate = (payload, privateKeyHex, cb) => {
 
   // Submit BatchList to Validator
   $.post({
-    url: `${API_URL}/batches?wait`,
+    url: `${API_URL}/batches`,
     data: batchListBytes,
     headers: {'Content-Type': 'application/octet-stream'},
     processData: false,
-    // Any data object indicates the Batch was not committed
-    success: ({ data }) => cb(!data),
+    success: function( resp ) {
+      var id = resp.link.split('?')[1]
+      $.get(`${API_URL}/batch_statuses?${id}&wait`, ({ data }) => cb(true))
+    },
     error: () => cb(false)
   })
 }


### PR DESCRIPTION
The TunaChain webapp automatically refreshes when a transaction is submitted. This is only useful if it waits until the new data is committed to state before the refresh happens. This PR adds a request to the `batch_statuses` endpoint to ensure that the batch is committed before refreshing.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>